### PR TITLE
IPアドレスを固定

### DIFF
--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       - "80:80"
     volumes:
       - ./settings/nginx.conf:/etc/nginx/nginx.conf
+    restart: always
     depends_on:
       - wordpress
       - phpmyadmin

--- a/terraform/eip.tf
+++ b/terraform/eip.tf
@@ -1,0 +1,6 @@
+resource "aws_eip" "eip" {
+  instance = aws_instance.ec2.id
+  tags = {
+    Name = "cloud-1-eip"
+  }
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,5 +1,5 @@
 output "ec2_ip" {
-  value = aws_instance.ec2.public_ip
+  value = aws_eip.eip.public_ip
 }
 
 output "ec2_dns" {


### PR DESCRIPTION
#### やったこと
- elastic IPを使ってインスタンスに静的IPアドレスを払出し
- nginxのコンテナのrestartオプションが抜けてたので追加

#### 確認したこと
- ec2の停止、開始を行なってもIPアドレスが変わらないこと
- インスタンスの再起動後、アプリケーションも起動すること
- インスタンスの再起動後、投稿した記事、画像の情報が保持されていること